### PR TITLE
Add support for viewing additional telemetry data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.csv
 *.html
+/venv/

--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@
    ```
 
 3. An HTML file named rangetest-map.html will be generated which can now be opened to view the range test results.
+
+#### Arguments
+
+##### `-e` `--exclude`
+
+GPS coordinate square to filter from display `<top-left>:<bottom-right>`
+
+Note: use `--exclude='<val>'` if top is a negative value.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Installation
 
 1. Clone the repository:
-   
+
    ```sh
    cd ~
    git clone https://github.com/TheCommsChannel/mesh-rangetest-map.git
@@ -11,53 +11,53 @@
    ```
    Or download the zip file from the green "Code" button above if on Windows
 
-2. Set up a Python virtual environment:  
-   
+2. Set up a Python virtual environment:
+
    ```sh
    python -m venv venv
    ```
 
-3. Activate the virtual environment:  
-   
-   - On Windows:  
-   
+3. Activate the virtual environment:
+
+   - On Windows:
+
    ```sh
-   venv\Scripts\activate  
+   venv\Scripts\activate
    ```
-   
+
    - On macOS and Linux:
-   
+
    ```sh
    source venv/bin/activate
    ```
 
-4. Install the required packages:  
-   
+4. Install the required packages:
+
    ```sh
    pip install -r requirements.txt
    ```
-   
+
 ### Usage
 
 1. Run Range Tests and place the csv files in the same directory. Change the name of the csv files to something that makes sense.
 
-2. Navigate to the `mesh-rangetest-map` directory if you're not already there and activate the virtual environment:  
-   
-   - On Windows:  
-   
+2. Navigate to the `mesh-rangetest-map` directory if you're not already there and activate the virtual environment:
+
+   - On Windows:
+
    ```sh
-   venv\Scripts\activate  
+   venv\Scripts\activate
    ```
-   
+
    - On macOS and Linux:
-   
+
    ```sh
    source venv/bin/activate
    ```
-3. Run the script with the following command:  
-   
+3. Run the script with the following command:
+
    ```sh
    python rtmap.py
    ```
-   
+
 3. An HTML file named rangetest-map.html will be generated which can now be opened to view the range test results.

--- a/rtmap.py
+++ b/rtmap.py
@@ -39,7 +39,7 @@ def create_point_layer(csv_file):
         else:
             color = mcolors.rgb2hex(cmap(row['normalized_snr']))
 
-        popup_info = f"{os.path.basename(csv_file)}<br>SNR: {row['rx snr']}<br>Elevation: {row['rx elevation']}"
+        popup_info = f"<div style='white-space:nowrap;'>{os.path.basename(csv_file)}<br>SNR: {row['rx snr']}<br>Elevation: {row['rx elevation']}</div>"
         folium.CircleMarker(
             location=[row['rx lat'], row['rx long']],
             radius=7,

--- a/rtmap.py
+++ b/rtmap.py
@@ -39,7 +39,7 @@ def create_point_layer(csv_file):
         else:
             color = mcolors.rgb2hex(cmap(row['normalized_snr']))
 
-        popup_info = f"<div style='white-space:nowrap;'>{os.path.basename(csv_file)}<br>SNR: {row['rx snr']}<br>Elevation: {row['rx elevation']}</div>"
+        popup_info = f"<div style='white-space:nowrap;'>{os.path.basename(csv_file)}<br>SNR: {row['rx snr']}<br>Elevation: {row['rx elevation']} <br>Sender Name: {row['sender name']}<br>Time: {row['time']}</div>"
         folium.CircleMarker(
             location=[row['rx lat'], row['rx long']],
             radius=7,

--- a/rtmap.py
+++ b/rtmap.py
@@ -4,10 +4,17 @@ import pandas as pd
 import folium
 import matplotlib.colors as mcolors
 from folium.plugins import MeasureControl
+from collections import defaultdict
 
 def create_point_layer(csv_file):
 
-    df_filtered = pd.read_csv(csv_file)
+    df_filtered = pd.read_csv(
+        csv_file,
+        dtype=defaultdict(lambda: "string", {
+            'rx lat': 'float',
+            'rx long': 'float',
+            'rx snr': 'float',
+            'rx elevation': 'float'}))
 
     # Filter invalid positions
     df_filtered = df_filtered[(df_filtered['sender name'].str.len() > 0) &

--- a/rtmap.py
+++ b/rtmap.py
@@ -5,6 +5,7 @@ import folium
 import matplotlib.colors as mcolors
 from folium.plugins import MeasureControl
 from collections import defaultdict
+from html import escape
 
 def create_point_layer(csv_file):
 
@@ -46,12 +47,13 @@ def create_point_layer(csv_file):
         else:
             color = mcolors.rgb2hex(cmap(row['normalized_snr']))
 
+
         popup_info = ("<div style='white-space:nowrap;'>"
-           f"{os.path.basename(csv_file)}"
+           f"{escape(os.path.basename(csv_file))}"
            f"<br>SNR: {row['rx snr']}"
            f"<br>Elevation: {row['rx elevation']}"
-           f"<br>Sender Name: {row['sender name']}"
-           f"<br>Time: {row['time']}"
+           f"<br>Sender Name: {escape(row['sender name'])}"
+           f"<br>Time: {escape(row['time'])}"
            "</div>")
 
         folium.CircleMarker(

--- a/rtmap.py
+++ b/rtmap.py
@@ -8,14 +8,12 @@ from collections import defaultdict
 from folium.plugins import MeasureControl
 from html import escape
 
-def create_point_layer(df_filtered, csv_file):
+def create_point_layer(df_filtered, layerName):
     # Create a FeatureGroup for the CSV file
-    layer = folium.FeatureGroup(name=csv_file)
+    layer = folium.FeatureGroup(name=layerName)
 
     # Define the color map (from red to green)
     cmap = mcolors.LinearSegmentedColormap.from_list("", ["red", "yellow", "green"])
-
-    df_filtered = df_filtered[(df_filtered['Source File'] == csv_file)]
 
     # Add a marker for each point
     for _, row in df_filtered.iterrows():
@@ -104,9 +102,15 @@ def create_map_with_layers(df_filtered, output_file):
 
     # CSV layers
     for csv_file in pd.unique(df_filtered['Source File']):
-        layer = create_point_layer(df_filtered, csv_file)
-        if layer:
-            layer.add_to(m)
+        payloads = ["NEIGHBORINFO","NODEINFO","POSITION","ROUTING","TELEMETRY", "seq"]
+        for payload in payloads:
+            subSet = df_filtered[df_filtered['payload'].str.contains(payload, na=False)]
+            subSet = subSet[(subSet['Source File'] == csv_file)]
+            if subSet.empty:
+                continue
+            layer = create_point_layer(subSet, csv_file + " " + payload)
+            if layer:
+                layer.add_to(m)
 
     folium.LayerControl(collapsed=False).add_to(m)
     m.save(output_file)

--- a/rtmap.py
+++ b/rtmap.py
@@ -10,6 +10,8 @@ def create_point_layer(csv_file):
     df_filtered = pd.read_csv(csv_file)
 
     # Filter invalid positions
+    df_filtered = df_filtered[(df_filtered['sender name'].str.len() > 0) &
+                              ~df_filtered['sender name'].str.contains('\(MQTT\)', na=False)]
     df_filtered = df_filtered[(df_filtered['rx lat'].apply(lambda x: isinstance(x, (int, float)))) &
                               (df_filtered['rx long'].apply(lambda x: isinstance(x, (int, float)))) &
                               (df_filtered['rx lat'].between(-90, 90)) &

--- a/rtmap.py
+++ b/rtmap.py
@@ -1,10 +1,10 @@
-import os
-import glob
-import pandas as pd
 import folium
+import glob
 import matplotlib.colors as mcolors
-from folium.plugins import MeasureControl
+import os
+import pandas as pd
 from collections import defaultdict
+from folium.plugins import MeasureControl
 from html import escape
 
 def create_point_layer(csv_file):

--- a/rtmap.py
+++ b/rtmap.py
@@ -28,8 +28,8 @@ def create_point_layer(csv_file):
     # Define the color map (from red to green)
     cmap = mcolors.LinearSegmentedColormap.from_list("", ["red", "yellow", "green"])
 
-    # Normalize the SNR values to a range for color mapping
-    df_filtered['normalized_snr'] = df_filtered['rx snr'].apply(lambda x: (x - (-21)) / (12 - (-21)))  # Normalize to range [-21, 12]
+    # Normalize the SNR values to a range [-21, 12] for color mapping
+    df_filtered['normalized_snr'] = df_filtered['rx snr'].apply(lambda x: (x - (-21)) / (12 - (-21)))
 
     # Add a marker for each point
     for _, row in df_filtered.iterrows():
@@ -39,7 +39,14 @@ def create_point_layer(csv_file):
         else:
             color = mcolors.rgb2hex(cmap(row['normalized_snr']))
 
-        popup_info = f"<div style='white-space:nowrap;'>{os.path.basename(csv_file)}<br>SNR: {row['rx snr']}<br>Elevation: {row['rx elevation']} <br>Sender Name: {row['sender name']}<br>Time: {row['time']}</div>"
+        popup_info = ("<div style='white-space:nowrap;'>"
+           f"{os.path.basename(csv_file)}"
+           f"<br>SNR: {row['rx snr']}"
+           f"<br>Elevation: {row['rx elevation']}"
+           f"<br>Sender Name: {row['sender name']}"
+           f"<br>Time: {row['time']}"
+           "</div>")
+
         folium.CircleMarker(
             location=[row['rx lat'], row['rx long']],
             radius=7,
@@ -117,7 +124,6 @@ def create_map_with_layers(csv_files, output_file):
 
     folium.LayerControl(collapsed=False).add_to(m)
     m.save(output_file)
-
 
 if __name__ == "__main__":
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/rtmap.py
+++ b/rtmap.py
@@ -7,11 +7,9 @@ from folium.plugins import MeasureControl
 
 def create_point_layer(csv_file):
 
-    df = pd.read_csv(csv_file)
+    df_filtered = pd.read_csv(csv_file)
 
-    # Row filtering
-    df_filtered = df[df['payload'].str.contains(r'seq \d+', na=False)]
-    df_filtered = df_filtered[['rx lat', 'rx long', 'rx snr', 'sender name', 'rx elevation']].dropna()
+    # Filter invalid positions
     df_filtered = df_filtered[(df_filtered['rx lat'].apply(lambda x: isinstance(x, (int, float)))) &
                               (df_filtered['rx long'].apply(lambda x: isinstance(x, (int, float)))) &
                               (df_filtered['rx lat'].between(-90, 90)) &


### PR DESCRIPTION
The rangtest.csv output includes additional data that can be useful to include on the map. Allows viewing all data in the file (excluding MQTT) and toggling those additional inputs as separate layers.

I also added a basic CLI flag for excluding measurements in a square (I found it handy for excluding my home position which had many measurements which caused the map to stutter when used).